### PR TITLE
Install the Android NDK into the Linux container

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -26,7 +26,9 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV ANDROID_NDK_VERSION=r21d
 ENV ANDROID_HOST=linux-x86_64
 
-RUN curl -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-${ANDROID_HOST}.zip \
+# We use HTTP/1.1, because of spurious HTTP/2 framing errors in the Azure / GitHub cloud.
+
+RUN curl --http1.1 -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-${ANDROID_HOST}.zip \
     && unzip android-ndk.zip \
     && rm android-ndk.zip
 ENV ANDROID_NDK=/android-ndk-${ANDROID_NDK_VERSION}

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -20,3 +20,15 @@ RUN apt-get update && apt-get install -y \
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-9 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-9
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install Android NDK
+
+ENV ANDROID_NDK_VERSION=r21d
+ENV ANDROID_HOST=linux-x86_64
+
+RUN curl -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-${ANDROID_HOST}.zip \
+    && unzip android-ndk.zip \
+    && rm android-ndk.zip
+ENV ANDROID_NDK=/android-ndk-${ANDROID_NDK_VERSION}
+ENV PATH=${PATH}:/android-ndk-${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/${ANDROID_HOST}/bin
+


### PR DESCRIPTION
This is an experiment to test if we can install the Android NDK into the container. Primarily to make the builds on Azure a little more robust.
