### PR TITLE
Update all windows dependencies to their latest versions

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -22,10 +22,10 @@ RUN powershell -Command \
 # rustup: checksums do not match
 RUN choco install -y git.install --params "/GitAndUnixToolsOnPath" \
     && choco install -y python2 --version 2.7.18 \
-    && choco install -y llvm --version 11.0.0 \
-    && choco install -y rust-ms --version 1.50.0 \
+    && choco install -y llvm --version 11.0.1 \
+    && choco install -y rust-ms --version 1.51.0 \
     && choco install -y rustup.install --version 1.22.1 --ignore-checksums \
-    && choco install -y visualstudio2019buildtools --version 16.8.3 \
+    && choco install -y visualstudio2019buildtools --version 16.9.2.0 \
        --package-parameters "--nocache --add Microsoft.VisualStudio.Workload.VCTools;includeRecommended" \
 	&& rmdir "C:\ProgramData\Package Cache" /s /q \
 	&& rmdir "C:\Users\ContainerAdministrator\AppData\Local\Temp\chocolatey" /s /q


### PR DESCRIPTION
This PR updates the Windows Dockerfile used to build the rust-skia binaries:

- LLVM 11.0.1
- rust-ms 1.51.0
- VS build tools 16.9.2
