### PR TITLE
Update Linux image to ubuntu 20

### DIFF
--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -30,31 +30,48 @@ RUN apt-get update && apt-get install -y \
 	mesa-common-dev \
 	pkg-config \
 	python \
-	unzip
+	unzip \
+	make \
+	libwayland-dev
 
-# aarch64 specific
+RUN update-alternatives \
+	--install /usr/bin/clang clang /usr/bin/clang-16 90 \
+	--slave /usr/bin/clang++ clang++ /usr/bin/clang++-16 \
+	--slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-16 \
+	--slave /usr/bin/c++ c++ /usr/bin/clang++-16
 
-RUN apt-get install -y \
-	ninja.build
+# Ninja
 
+RUN apt-get install -y ninja.build
 ENV SKIA_NINJA_COMMAND=/usr/bin/ninja
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-16 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-16
+# Rust
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Android NDK
+# Android NDK
 
 ENV ANDROID_NDK_VERSION=r26d
 ENV ANDROID_HOST=linux-aarch64
-
-# HTTP/1.1, because of spurious HTTP/2 framing errors in the Azure / GitHub cloud.
-
-RUN curl --http1.1 -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip \
+RUN curl -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip \
  && unzip android-ndk.zip \
  && rm android-ndk.zip
-
 ENV ANDROID_NDK=/android-ndk-${ANDROID_NDK_VERSION}
 ENV PATH=${PATH}:/android-ndk-${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/${ANDROID_HOST}/bin
 
+# Emscripten SDK
+
+ENV EMSCRIPTEN_VER=3.1.59
+RUN git clone https://github.com/emscripten-core/emsdk.git \
+	&& (cd emsdk && ./emsdk install ${EMSCRIPTEN_VER}) \
+	&& (cd emsdk && ./emsdk activate ${EMSCRIPTEN_VER})
+ENV EMSDK=/emsdk
+
+# Wasi SDK
+
+RUN curl -L -o wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0-linux.tar.gz \
+	&& tar -xzf wasi-sdk.tar.gz \
+	&& rm wasi-sdk.tar.gz \
+	&& mv wasi-sdk-22.0 /opt/
+ENV WASI_SDK=/opt/wasi-sdk-22.0

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -35,7 +35,11 @@ RUN apt-get update && apt-get install -y \
 	unzip \
 	make
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-16 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-16
+RUN update-alternatives \
+	--install /usr/bin/clang clang /usr/bin/clang-16 90 \
+	--slave /usr/bin/clang++ clang++ /usr/bin/clang++-16 \
+	--slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-16 \
+	--slave /usr/bin/c++ c++ /usr/bin/clang++-16
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,6 +1,6 @@
 # This container is based on ubuntu 18 because we need to link with libstdc++ 6.0.25 because of ABI incompatibilities.
 # <https://github.com/rust-skia/rust-skia/issues/393>
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL org.opencontainers.image.source https://github.com/pragmatrix/rust-skia-containers
 
 # For github actions we need a newer git version
@@ -10,9 +10,9 @@ RUN apt-get update \
 
 RUN apt-get install -y wget
 
-## Add llvm package repository for ubuntu 18 (bionic)
+## Add llvm package repository for ubuntu 20 (focal))
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-16 main"
+RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
 
 # unzip: for installing the Android NDK
 # libgl1 libgl1-mesa-dev mesa-common-dev: for builds that need OpenGL

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -18,6 +18,7 @@ RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 m
 # libgl1 libgl1-mesa-dev mesa-common-dev: for builds that need OpenGL
 # libgles2-mesa-dev for egl support.
 # clang-16 / g++-16 is needed for more recent emscripten builds.
+# make is needed for supplemental builds.
 RUN apt-get update && apt-get install -y \
 	curl \
 	gcc \
@@ -31,7 +32,8 @@ RUN apt-get update && apt-get install -y \
 	mesa-common-dev \
 	pkg-config \
 	python \
-	unzip
+	unzip \
+	make
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-16 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-16
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update && apt-get install -y \
 	pkg-config \
 	python \
 	unzip \
-	make
+	make \
+	libwayland-dev
 
 RUN update-alternatives \
 	--install /usr/bin/clang clang /usr/bin/clang-16 90 \


### PR DESCRIPTION
To work around #10 and support node 20, I think it's probably the easiest way to update the Linux image to ubuntu 20, even though this might break GLIBC compatibility in binary builds of older platforms. 